### PR TITLE
Fixed bug where the displayFormat was affecting highlighted dates

### DIFF
--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -215,8 +215,8 @@ const Datepicker: React.FC<Props> = ({
                 validDate && (startDate.isSame(endDate) || startDate.isBefore(endDate));
             if (condition) {
                 setPeriod({
-                    start: formatDate(startDate, displayFormat),
-                    end: formatDate(endDate, displayFormat)
+                    start: formatDate(startDate),
+                    end: formatDate(endDate)
                 });
                 setInputText(
                     `${formatDate(startDate, displayFormat)}${


### PR DESCRIPTION
The bug was because I was accidentally formatting the dates being stored in the `period`

Linked issue: #42 