### PR TITLE
update days button width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules/
 /package-lock.json
 /yarn.lock
+/pnpm-lock.yaml
 /.next/
 /.rollup.cache/
 

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -230,7 +230,8 @@ const Days: React.FC<Props> = ({
 
     const buttonClass = useCallback(
         (day: number, type: string) => {
-            const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10";
+            const baseClass =
+                "flex items-center justify-center min-w-[48px] md:min-w-0 h-12 lg:h-10";
             return cn(
                 baseClass,
                 !activeDateData(day).active ? hoverClassByDay(day) : activeDateData(day).className,
@@ -282,7 +283,7 @@ const Days: React.FC<Props> = ({
                     type="button"
                     key={index}
                     disabled={isDateDisabled(item, "previous")}
-                    className="flex items-center justify-center text-gray-400 h-12 w-12 lg:w-10 lg:h-10"
+                    className="flex items-center justify-center text-gray-400 min-w-[48px] md:min-w-0 h-12 lg:h-10"
                     onClick={() => onClickPreviousDays(item)}
                     onMouseOver={() => {
                         hoverDay(item, "previous");
@@ -314,7 +315,7 @@ const Days: React.FC<Props> = ({
                     type="button"
                     key={index}
                     disabled={isDateDisabled(index, "next")}
-                    className="flex items-center justify-center text-gray-400 h-12 w-12 lg:w-10 lg:h-10"
+                    className="flex items-center justify-center text-gray-400 min-w-[48px] md:min-w-0 h-12 lg:h-10"
                     onClick={() => {
                         onClickNextDays(item);
                     }}


### PR DESCRIPTION
## As is:

1. splitted bg

<img width="706" alt="Screenshot 2023-02-04 at 10 37 12 AM" src="https://user-images.githubusercontent.com/73801151/216757945-ca6242ab-6a48-4547-8a2c-0a6e1b88b02b.png">

2. day button is not center

<img width="323" alt="Screenshot 2023-02-04 at 5 44 46 PM" src="https://user-images.githubusercontent.com/73801151/216758059-9464c67f-4a0b-4f81-8a3f-24afa9a7ea1a.png">

## To be

<img width="639" alt="Screenshot 2023-02-04 at 10 46 11 AM" src="https://user-images.githubusercontent.com/73801151/216757951-80a46dba-57aa-4845-aaa3-1e0c3bfbfccc.png">

<img width="356" alt="image" src="https://user-images.githubusercontent.com/73801151/216758140-47fa46f5-8bec-4a73-bfd6-355eeb7dcd22.png">


