### PR TITLE
[Fix] Proper Tailwind CSS classes overrides (#64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     ],
     "peerDependencies": {
         "dayjs": "^1.11.6",
-        "react": "^17.0.2 || ^18.2.0"
+        "react": "^17.0.2 || ^18.2.0",
+        "tailwind-merge": "^1.9.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.1",
@@ -62,6 +63,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^2.77.2",
+        "tailwind-merge": "^1.9.1",
         "tailwindcss": "^3.2.4",
         "tslib": "^2.4.0",
         "typescript": "^4.8.4"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,15 +12,17 @@ module.exports = {
             file: packageJson.main,
             format: "cjs",
             exports: "auto",
+            inlineDynamicImports: true,
             sourcemap: true
         },
         {
             file: packageJson.module,
             format: "esm",
             exports: "auto",
+            inlineDynamicImports: true,
             sourcemap: true
         }
     ],
-    external: ["react", "dayjs"],
+    external: ["react", "dayjs", "tailwind-merge"],
     plugins: [resolve(), commonjs(), typescript({ ...options.compilerOptions, jsx: "react" })]
 };

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { twMerge } from "tailwind-merge";
 
 import Calendar from "../components/Calendar";
 import Footer from "../components/Footer";
@@ -341,7 +342,7 @@ const Datepicker: React.FC<Props> = ({
     return (
         <DatepickerContext.Provider value={contextValues}>
             <div
-                className={`relative w-full text-gray-700 ${containerClassName}`}
+                className={twMerge(`relative w-full text-gray-700 ${containerClassName}`)}
                 ref={containerRef}
             >
                 <Input setContextRef={setInputRef} />

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import React, { useCallback, useContext, useEffect, useRef } from "react";
+import { twMerge } from "tailwind-merge";
 
 import { BORDER_COLOR, RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
@@ -60,7 +61,9 @@ const Input: React.FC<Props> = (e: Props) => {
         const ring =
             RING_COLOR["second-focus"][primaryColor as keyof (typeof RING_COLOR)["second-focus"]];
         const classNameOverload = typeof inputClassName === "string" ? inputClassName : "";
-        return `relative transition-all duration-300 py-2.5 pl-4 pr-14 w-full border-gray-300 dark:bg-slate-800 dark:text-white/80 dark:border-slate-600 rounded-lg tracking-wide font-light text-sm placeholder-gray-400 bg-white focus:ring disabled:opacity-40 disabled:cursor-not-allowed ${border} ${ring} ${classNameOverload}`;
+        return twMerge(
+            `relative transition-all duration-300 py-2.5 pl-4 pr-14 w-full border-gray-300 dark:bg-slate-800 dark:text-white/80 dark:border-slate-600 rounded-lg tracking-wide font-light text-sm placeholder-gray-400 bg-white focus:ring disabled:opacity-40 disabled:cursor-not-allowed ${border} ${ring} ${classNameOverload}`
+        );
     }, [inputRef, classNames, primaryColor, inputClassName]);
 
     const handleInputChange = useCallback(
@@ -215,7 +218,9 @@ const Input: React.FC<Props> = (e: Props) => {
             return classNames.toggleButton(button);
         }
 
-        return `absolute right-0 h-full px-3 text-gray-400 focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed ${toggleClassName}`;
+        return twMerge(
+            `absolute right-0 h-full px-3 text-gray-400 focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed ${toggleClassName}`
+        );
     }, [toggleClassName, buttonRef, classNames]);
 
     return (


### PR DESCRIPTION
Thanks to [tailwind-merge](https://github.com/dcastil/tailwind-merge) provided `inputClassName`/`containerClassName`/`toggleClassName` props will now work correctly.

Before:
<img src="https://user-images.githubusercontent.com/1763109/217781205-66b664db-988e-40b6-afa1-d432af63c3e1.png" width=50% height=50%>

After:
<img src="https://user-images.githubusercontent.com/1763109/217781234-251864f3-0fcb-419b-b1e1-bc4258a3095c.png" width=50% height=50%>


