### PR TITLE
Updating shortcuts to hide when ommited

### DIFF
--- a/src/components/Shortcuts.tsx
+++ b/src/components/Shortcuts.tsx
@@ -97,7 +97,10 @@ const Shortcuts: React.FC = () => {
 
     const shortcutOptions = configs
         ? Object.entries(DEFAULT_SHORTCUTS).filter(([key]) => {
-              return configs.shortcuts ? Object.keys(configs.shortcuts).includes(key) : true;
+              return configs.shortcuts
+                  ? Object.keys(configs.shortcuts).includes(key) &&
+                        configs.shortcuts[key as keyof typeof configs.shortcuts]
+                  : true;
           })
         : Object.entries(DEFAULT_SHORTCUTS);
 

--- a/src/components/Shortcuts.tsx
+++ b/src/components/Shortcuts.tsx
@@ -83,7 +83,11 @@ const ItemTemplate = React.memo((props: ItemTemplateProps) => {
     );
 });
 
-const Shortcuts = () => {
+const printItemText = (item: ShortcutsItem) => {
+    return item.text ?? null;
+};
+
+const Shortcuts: React.FC = () => {
     // Contexts
     const { configs } = useContext(DatepickerContext);
 
@@ -91,21 +95,24 @@ const Shortcuts = () => {
         return typeof data === "function" ? data(numberValue) : null;
     };
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const printItemText = item => {
-        return "text" in item ? item.text : "";
-    };
+    const shortcutOptions = configs
+        ? Object.entries(DEFAULT_SHORTCUTS).filter(([key]) => {
+              return configs.shortcuts ? Object.keys(configs.shortcuts).includes(key) : true;
+          })
+        : Object.entries(DEFAULT_SHORTCUTS);
 
     return (
         <div className="md:border-b mb-3 lg:mb-0 lg:border-r lg:border-b-0 border-gray-300 dark:border-gray-700 pr-1">
             <ul className="w-full tracking-wide flex flex-wrap lg:flex-col pb-1 lg:pb-0">
-                {Object.entries(DEFAULT_SHORTCUTS).map(([key, item], index) =>
-                    key === "past" ? (
-                        (Array.isArray(item) ? item : []).map((item, index) => (
+                {shortcutOptions.map(([key, item], index) =>
+                    Array.isArray(item) ? (
+                        item.map((item, index) => (
                             <ItemTemplate key={index} item={item}>
                                 <>
-                                    {configs && configs.shortcuts && key in configs.shortcuts
+                                    {key === "past" &&
+                                    configs?.shortcuts &&
+                                    key in configs.shortcuts &&
+                                    item.daysNumber
                                         ? callPastFunction(configs.shortcuts[key], item.daysNumber)
                                         : item.text}
                                 </>
@@ -114,7 +121,7 @@ const Shortcuts = () => {
                     ) : (
                         <ItemTemplate key={index} item={item}>
                             <>
-                                {configs && configs.shortcuts && key in configs.shortcuts
+                                {configs?.shortcuts && key in configs.shortcuts
                                     ? configs.shortcuts[key as keyof typeof configs.shortcuts]
                                     : printItemText(item)}
                             </>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,6 +2,8 @@ import dayjs from "dayjs";
 
 import { formatDate, previousMonth } from "../helpers";
 
+import { ShortcutsItem } from "types";
+
 export const COLORS = [
     "blue",
     "orange",
@@ -270,7 +272,9 @@ export const BUTTON_COLOR = {
     }
 };
 
-export const DEFAULT_SHORTCUTS = {
+export const DEFAULT_SHORTCUTS: {
+    [key in string]: ShortcutsItem | ShortcutsItem[];
+} = {
     today: {
         text: "Today",
         period: {


### PR DESCRIPTION
When setting shortcut config settings, omit the buttons for unset options

When setting a config like 
```
{ 
    shortcuts: {
        today: 'Today',
        yesterday: null,
        past: null,
        currentMonth: 'This Month',
        pastMonth: null   
    }
}
```
or
```
{ 
    shortcuts: {
        today: 'Today',
        currentMonth: 'This Month',
    }
}
```

We should not show a button for the omitted values, to allow end users to hide options they don't want

Before:
<img width="740" alt="Screenshot 2023-02-25 at 7 44 12 PM" src="https://user-images.githubusercontent.com/9310513/221386281-1e0ab054-d69f-410c-8cad-04ecb1307378.png">

After:
<img width="739" alt="Screenshot 2023-02-25 at 7 42 51 PM" src="https://user-images.githubusercontent.com/9310513/221386280-387af028-86bd-437e-b77f-1c19d38a6b2b.png">

