### PR TITLE
Added initial support for displaying (only) the year picker, only works for single date datepicker so far

### DIFF
--- a/src/components/Calendar/Years.tsx
+++ b/src/components/Calendar/Years.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import { generateArrayNumber } from "../../helpers";
 import { RoundedButton } from "../utils";
+
+import DatepickerContext from "contexts/DatepickerContext";
 
 interface Props {
     year: number;
@@ -9,9 +11,14 @@ interface Props {
 }
 
 const Years: React.FC<Props> = ({ year, clickYear }) => {
+    const { yearPickerStartYearOffset } = useContext(DatepickerContext);
+
     return (
         <div className="w-full grid grid-cols-2 gap-2 mt-2">
-            {generateArrayNumber(year, year + 11).map((item, index) => (
+            {generateArrayNumber(
+                year + (yearPickerStartYearOffset || 0),
+                year + (yearPickerStartYearOffset || 0) + 11
+            ).map((item, index) => (
                 <RoundedButton
                     key={index}
                     padding="py-3"

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -33,6 +33,7 @@ interface Props {
     onClickNext: () => void;
     changeMonth: (month: number) => void;
     changeYear: (year: number) => void;
+    showYearPicker?: boolean;
 }
 
 const Calendar: React.FC<Props> = ({
@@ -40,7 +41,8 @@ const Calendar: React.FC<Props> = ({
     onClickPrevious,
     onClickNext,
     changeMonth,
-    changeYear
+    changeYear,
+    showYearPicker
 }) => {
     // Contexts
     const {
@@ -59,7 +61,7 @@ const Calendar: React.FC<Props> = ({
 
     // States
     const [showMonths, setShowMonths] = useState(false);
-    const [showYears, setShowYears] = useState(false);
+    const [showYears, setShowYears] = useState(showYearPicker);
     const [year, setYear] = useState(date.year());
     // Functions
     const previous = useCallback(() => {
@@ -102,7 +104,18 @@ const Calendar: React.FC<Props> = ({
         (year: number) => {
             setTimeout(() => {
                 changeYear(year);
-                setShowYears(!showYears);
+                setShowYears(showYearPicker ? true : !showYears);
+                if (showYearPicker && asSingle) {
+                    const ipt = input?.current;
+                    changeDatepickerValue(
+                        {
+                            startDate: String(year) + "-1-1",
+                            endDate: String(year) + "-1-1"
+                        },
+                        ipt
+                    );
+                    hideDatepicker();
+                }
             }, 250);
         },
         [changeYear, showYears]

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -27,6 +27,7 @@ interface Props {
     useRange?: boolean;
     showFooter?: boolean;
     showShortcuts?: boolean;
+    showYearPicker?: boolean;
     configs?: {
         shortcuts?: {
             today?: string;
@@ -87,7 +88,8 @@ const Datepicker: React.FC<Props> = ({
     inputId,
     inputName,
     startWeekOn = "sun",
-    classNames = undefined
+    classNames = undefined,
+    showYearPicker = false
 }) => {
     // Ref
     const containerRef = useRef<HTMLDivElement>(null);
@@ -377,6 +379,7 @@ const Datepicker: React.FC<Props> = ({
                                     onClickNext={nextMonthFirst}
                                     changeMonth={changeFirstMonth}
                                     changeYear={changeFirstYear}
+                                    showYearPicker={showYearPicker}
                                 />
 
                                 {useRange && (

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -60,6 +60,7 @@ interface Props {
     maxDate?: DateType | null;
     disabledDates?: DateRangeType[] | null;
     startWeekOn?: string | null;
+    yearPickerStartYearOffset?: number;
 }
 
 const Datepicker: React.FC<Props> = ({
@@ -89,7 +90,8 @@ const Datepicker: React.FC<Props> = ({
     inputName,
     startWeekOn = "sun",
     classNames = undefined,
-    showYearPicker = false
+    showYearPicker = false,
+    yearPickerStartYearOffset = undefined
 }) => {
     // Ref
     const containerRef = useRef<HTMLDivElement>(null);
@@ -316,7 +318,8 @@ const Datepicker: React.FC<Props> = ({
             startWeekOn,
             classNames,
             onChange,
-            input: inputRef
+            input: inputRef,
+            yearPickerStartYearOffset
         };
     }, [
         asSingle,
@@ -347,7 +350,8 @@ const Datepicker: React.FC<Props> = ({
         inputName,
         startWeekOn,
         classNames,
-        inputRef
+        inputRef,
+        yearPickerStartYearOffset
     ]);
 
     return (

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -47,6 +47,7 @@ interface DatepickerStore {
     inputId?: string;
     inputName?: string;
     classNames?: ClassNamesTypeProp | undefined;
+    yearPickerStartYearOffset?: number;
 }
 
 const DatepickerContext = createContext<DatepickerStore>({
@@ -91,7 +92,8 @@ const DatepickerContext = createContext<DatepickerStore>({
     inputName: undefined,
     startWeekOn: START_WEEK,
     toggleIcon: undefined,
-    classNames: undefined
+    classNames: undefined,
+    yearPickerStartYearOffset: undefined
 });
 
 export default DatepickerContext;


### PR DESCRIPTION
The first commit adds a prop "showYearPicker" to the Datepicker which is just passed to the Calendar component, which just sets `const [showYears, setShowYears] = useState(showYearPicker);`. When a year is selected, the clickYear callback just sets the startDate and endDate to the first of January of the selected year.

The second commit adds a prop "yearPickerStartYearOffset" which offsets the years displayed in the year picker. For example if year is 2023 and `yearPickerStartYearOffset = -10` the year picker now displays the years 2013-2024 instead of the default 2023-2034.