### PR TITLE
[style] Disabled dates in next or previous months are not visually disabled

### DIFF
--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -204,7 +204,7 @@ const Days: React.FC<Props> = ({
     );
 
     const buttonClass = useCallback(
-        (day: number, type: "current" | "previous" | "next") => {
+        (day: number, type: "current" | "next" | "previous") => {
             const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10";
             return cn(
                 baseClass,

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -206,12 +206,16 @@ const Days: React.FC<Props> = ({
     const buttonClass = useCallback(
         (day: number, type: "current" | "next" | "previous") => {
             const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10";
-            return cn(
-                baseClass,
-                !activeDateData(day).active ? hoverClassByDay(day) : activeDateData(day).className,
-                isDateDisabled(day, type) && "line-through",
-                (type == "previous" || type == "next") && "text-gray-400"
-            );
+            if (type === "current") {
+                return cn(
+                    baseClass,
+                    !activeDateData(day).active
+                        ? hoverClassByDay(day)
+                        : activeDateData(day).className,
+                    isDateDisabled(day, type) && "line-through"
+                );
+            }
+            return cn(baseClass, isDateDisabled(day, type) && "line-through", "text-gray-400");
         },
         [activeDateData, hoverClassByDay, isDateDisabled]
     );

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -209,7 +209,8 @@ const Days: React.FC<Props> = ({
             return cn(
                 baseClass,
                 !activeDateData(day).active ? hoverClassByDay(day) : activeDateData(day).className,
-                isDateDisabled(day, type) && "line-through"
+                isDateDisabled(day, type) && "line-through",
+                (type == "previous" || type == "next") && "text-gray-400"
             );
         },
         [activeDateData, hoverClassByDay, isDateDisabled]
@@ -345,7 +346,7 @@ const Days: React.FC<Props> = ({
                     type="button"
                     key={index}
                     disabled={isDateDisabled(item, "previous")}
-                    className="flex items-center justify-center text-gray-400 h-12 w-12 lg:w-10 lg:h-10"
+                    className={`${buttonClass(item, "previous")}`}
                     onClick={() => handleClickDay(item, "previous")}
                     onMouseOver={() => {
                         hoverDay(item, "previous");
@@ -375,7 +376,7 @@ const Days: React.FC<Props> = ({
                     type="button"
                     key={index}
                     disabled={isDateDisabled(item, "next")}
-                    className="flex items-center justify-center text-gray-400 h-12 w-12 lg:w-10 lg:h-10"
+                    className={`${buttonClass(item, "next")}`}
                     onClick={() => handleClickDay(item, "next")}
                     onMouseOver={() => {
                         hoverDay(item, "next");


### PR DESCRIPTION
## Description

When disabling dates via `minDate`, `maxDate`, or `disabledDates`, the disabled dates in the previous or next month appear to be clickable. The issue is they are missing the `line-through` class

Fixes: https://github.com/onesine/react-tailwindcss-datepicker/issues/90

## Changes
- Previous & next date styles should be consistent
- Narrow types allowed for type argument in the buttonClass function

**Before:** 
<img width="827" alt="disabled dates issue" src="https://user-images.githubusercontent.com/17683847/224859713-06510d9e-c7d2-4522-9b51-d3f8eb9215ba.png">

**After:**
<img width="827" alt="disabled dates fixed" src="https://user-images.githubusercontent.com/17683847/224860768-ac583b96-c337-4950-98c4-6ef766748ad4.png">

