### PR TITLE
fix readme copy/paste npm/yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Go to [full documentation](https://react-tailwindcss-datepicker.vercel.app/)
 ### Install via npm
 
 ```
-$ npm install react-tailwindcss-datepicker 
+npm install react-tailwindcss-datepicker 
 ```
 
 ### Install via yarn
 
 ```
-$ yarn add react-tailwindcss-datepicker 
+yarn add react-tailwindcss-datepicker 
 ```
 
 Make sure you have installed the peer dependencies as well with the below versions.


### PR DESCRIPTION
If we use the copy button from GIthub UI, we don't want to copy the `$`