### PR TITLE
[Fix] Prevent duplicate keys in shortcut list.

### DIFF
--- a/src/components/Shortcuts.tsx
+++ b/src/components/Shortcuts.tsx
@@ -111,7 +111,7 @@ const Shortcuts: React.FC = () => {
             <ul className="w-full tracking-wide flex flex-wrap lg:flex-col pb-1 lg:pb-0">
                 {shortcutOptions.map(([key, item], index) =>
                     Array.isArray(item) ? (
-                        item.map((item, index) => (
+                        item.map((item) => (
                             <ItemTemplate key={index} item={item}>
                                 <>
                                     {key === "past" &&


### PR DESCRIPTION
Using the `index` from the inner `map` alongside the `index` from the outer `map` function results in duplicate key attributes in the shortcut list, which is not allowed by react. The problem can be reproduced using the default shortcut list.