### PR TITLE
Fixes format of return value when Apply button is clicked

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import React, { useCallback, useContext } from "react";
 
 import DatepickerContext from "../contexts/DatepickerContext";
@@ -32,8 +33,8 @@ const Footer: React.FC = () => {
                     onClick={() => {
                         if (period.start && period.end) {
                             changeDatepickerValue({
-                                startDate: period.start,
-                                endDate: period.end
+                                startDate: dayjs(period.start).format("YYYY-MM-DD"),
+                                endDate: dayjs(period.end).format("YYYY-MM-DD")
                             });
                             hideDatepicker();
                         }


### PR DESCRIPTION
This fixes the issue related to https://github.com/onesine/react-tailwindcss-datepicker/pull/61

ISO 8601 needs to be used when the "Apply" button is clicked in the footer.

The PR handles formatting the start and end dates by using dayjs .