### PR TITLE
Pass right day to isDateDisabled to avoid being able to select disabled days

### DIFF
--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -400,7 +400,7 @@ const Days: React.FC<Props> = ({
                 <button
                     type="button"
                     key={index}
-                    disabled={isDateDisabled(index, "next")}
+                    disabled={isDateDisabled(item, "next")}
                     className="flex items-center justify-center text-gray-400 h-12 w-12 lg:w-10 lg:h-10"
                     onClick={() => handleClickDay(item, "next")}
                     onMouseOver={() => {


### PR DESCRIPTION
This PR fixes an issue that allows selecting the 1st day of the following month when it has been disabled with a `maxDate`. This only happens when the current month is 31 days long and `maxDate` is set to the last day of the month.

Example:

```tsx
<Datepicker
  value={{ startDate: null, endDate: null }}
  minDate={new Date('2023-08-01')}
  maxDate={new Date('2023-08-31')}
  useRange={false}
  asSingle={true}           
 />
```

This allows selecting September 1st when clicking on it from August's view:

<img width="323" alt="Screenshot 2023-04-20 at 5 13 45 PM" src="https://user-images.githubusercontent.com/7077269/233489055-cbeedcd6-b894-491f-b2ec-56f2451692fc.png">
