### PR TITLE
Only apply active classes if the date belongs to the current month

### DIFF
--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -234,7 +234,10 @@ const Days: React.FC<Props> = ({
             const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10";
             return cn(
                 baseClass,
-                !activeDateData(day).active ? hoverClassByDay(day) : activeDateData(day).className,
+                type === "current" &&
+                    (!activeDateData(day).active
+                        ? hoverClassByDay(day)
+                        : activeDateData(day).className),
                 isDateDisabled(day, type) && "line-through"
             );
         },


### PR DESCRIPTION
This PR fixes an issue when selecting a day in the current month, if the same day from the previous or the next month is in the screen it will also show as selected. Active classes should only be applied to days in the current month.

<img width="331" alt="Screenshot 2023-04-21 at 2 12 19 PM" src="https://user-images.githubusercontent.com/7077269/233723402-d3e15da9-3826-49bf-bbff-556495cec744.png">
