### PR TITLE
Custom dates parsing error

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -77,20 +77,26 @@ const Input: React.FC<Props> = (e: Props) => {
                 }
             } else {
                 const parsed = inputValue.split(separator);
-                if (parsed.length === 2) {
-                    const startDate = parseFormattedDate(parsed[0], displayFormat);
-                    const endDate = parseFormattedDate(parsed[1], displayFormat);
 
-                    if (
-                        dateIsValid(startDate.toDate()) &&
-                        dateIsValid(endDate.toDate()) &&
-                        startDate.isBefore(endDate)
-                    ) {
-                        dates.push(startDate.format(DATE_FORMAT));
-                        dates.push(endDate.format(DATE_FORMAT));
-                    }
+                let startDate = null;
+                let endDate = null;
+
+                if (parsed.length === 2) {
+                    startDate = parseFormattedDate(parsed[0], displayFormat);
+                    endDate = parseFormattedDate(parsed[1], displayFormat);
                 } else {
-                    // TODO: Handle the case where there is separator in the date format or no separator at all
+                    const middle = Math.floor(inputValue.length / 2);
+                    startDate = parseFormattedDate(inputValue.slice(0, middle), displayFormat);
+                    endDate = parseFormattedDate(inputValue.slice(middle), displayFormat);
+                }
+
+                if (
+                    dateIsValid(startDate.toDate()) &&
+                    dateIsValid(endDate.toDate()) &&
+                    startDate.isBefore(endDate)
+                ) {
+                    dates.push(startDate.format(DATE_FORMAT));
+                    dates.push(endDate.format(DATE_FORMAT));
                 }
             }
 

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -30,7 +30,7 @@ interface DatepickerStore {
     changeDatepickerValue: (value: DateValueType, e?: HTMLInputElement | null | undefined) => void;
     showFooter?: boolean;
     placeholder?: string | null;
-    separator?: string;
+    separator: string;
     i18n: string;
     value: DateValueType;
     disabled?: boolean;
@@ -40,7 +40,7 @@ interface DatepickerStore {
     toggleIcon?: (open: boolean) => React.ReactNode;
     readOnly?: boolean;
     startWeekOn?: string | null;
-    displayFormat?: string;
+    displayFormat: string;
     minDate?: DateType | null;
     maxDate?: DateType | null;
     disabledDates?: DateRangeType[] | null;
@@ -94,7 +94,8 @@ const DatepickerContext = createContext<DatepickerStore>({
     startWeekOn: START_WEEK,
     toggleIcon: undefined,
     classNames: undefined,
-    popoverDirection: undefined
+    popoverDirection: undefined,
+    separator: "~"
 });
 
 export default DatepickerContext;


### PR DESCRIPTION
Due to the changes in parsing, in some cases it would not be possible to use a custom format with length different than 10 characters.

Changes:

- For `asSingle` input, use whole input to parse the date
- For not `asSingle` input, use separator or try to split input in half.
- **It doesn't hide date picker by default when a correct date is entered - ENTER key has to be pressed.** This is due to the fact that if someone is using a single day or month, and they want to type 10, typing 1 would close the date picker and remove the focus from the input. Now they can type 1, then 2 to get 12 and press enter. Example: If using format YYYY-M-D if you want to get 10th January 2023, after typing 2023-1-1 it would close the picker and lose focus for input. Now you can type 2023-1-10, on change will fire twice for 2023-1-1 and 2023-1-10, but only after pressing enter or clicking outside you will close date picker and lose focus. 
- separator and displayFormat are not nullable, there is always some value for them (either default or user input)

Checked with multiple date formats, both single and not. 

Works also for case described by @poshiemaaat [here](https://github.com/onesine/react-tailwindcss-datepicker/pull/63#issuecomment-1544021762).

We could look into adding unit testing? @onesine 

![image](https://github.com/onesine/react-tailwindcss-datepicker/assets/32863519/b3fa9d5a-40bc-4578-b82f-653a3585a221)