### PR TITLE
Fix min date

### DIFF
--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -60,20 +60,14 @@ const Days: React.FC<Props> = ({
             let className = "";
 
             if (dayjs(fullDay).isSame(period.start) && dayjs(fullDay).isSame(period.end)) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium rounded-full`;
             } else if (dayjs(fullDay).isSame(period.start)) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium ${
                     dayjs(fullDay).isSame(dayHover) && !period.end
                         ? "rounded-full"
                         : "rounded-l-full"
                 }`;
             } else if (dayjs(fullDay).isSame(period.end)) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium ${
                     dayjs(fullDay).isSame(dayHover) && !period.start
                         ? "rounded-full"
@@ -97,11 +91,7 @@ const Days: React.FC<Props> = ({
             }`;
 
             if (period.start && period.end) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 if (dayjs(fullDay).isBetween(period.start, period.end, "day", "[)")) {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
                     return ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
                         day
                     )} dark:bg-white/10`;
@@ -109,34 +99,22 @@ const Days: React.FC<Props> = ({
             }
 
             if (!dayHover) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 return className;
             }
 
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             if (period.start && dayjs(fullDay).isBetween(period.start, dayHover, "day", "[)")) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 className = ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
                     day
                 )} dark:bg-white/10`;
             }
 
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             if (period.end && dayjs(fullDay).isBetween(dayHover, period.end, "day", "[)")) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 className = ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
                     day
                 )} dark:bg-white/10`;
             }
 
             if (dayHover === fullDay) {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 const bgColor = BG_COLOR["500"][primaryColor];
                 className = ` transition-all duration-500 text-white font-medium ${bgColor} ${
                     period.start ? "rounded-r-full" : "rounded-l-full"

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -149,7 +149,7 @@ const Days: React.FC<Props> = ({
     );
 
     const isDateTooEarly = useCallback(
-        (day: number, type: string) => {
+        (day: number, type: "current" | "previous" | "next") => {
             if (!minDate) {
                 return false;
             }
@@ -159,10 +159,8 @@ const Days: React.FC<Props> = ({
                 next: nextMonth(calendarData.date)
             };
             const newDate = object[type as keyof typeof object];
-            const formattedDate = `${newDate.year()}-${newDate.month() + 1}-${
-                day >= 10 ? day : "0" + day
-            }`;
-            return dayjs(formattedDate).isSame(dayjs(minDate))
+            const formattedDate = newDate.set("date", day);
+            return dayjs(formattedDate).isSame(dayjs(minDate), "day")
                 ? false
                 : dayjs(formattedDate).isBefore(dayjs(minDate));
         },
@@ -170,7 +168,7 @@ const Days: React.FC<Props> = ({
     );
 
     const isDateTooLate = useCallback(
-        (day: number, type: string) => {
+        (day: number, type: "current" | "previous" | "next") => {
             if (!maxDate) {
                 return false;
             }
@@ -180,10 +178,8 @@ const Days: React.FC<Props> = ({
                 next: nextMonth(calendarData.date)
             };
             const newDate = object[type as keyof typeof object];
-            const formattedDate = `${newDate.year()}-${newDate.month() + 1}-${
-                day >= 10 ? day : "0" + day
-            }`;
-            return dayjs(formattedDate).isSame(maxDate)
+            const formattedDate = newDate.set("date", day);
+            return dayjs(formattedDate).isSame(dayjs(maxDate), "day")
                 ? false
                 : dayjs(formattedDate).isAfter(dayjs(maxDate));
         },
@@ -191,7 +187,7 @@ const Days: React.FC<Props> = ({
     );
 
     const isDateDisabled = useCallback(
-        (day: number, type: string) => {
+        (day: number, type: "current" | "previous" | "next") => {
             if (isDateTooEarly(day, type) || isDateTooLate(day, type)) {
                 return true;
             }
@@ -230,7 +226,7 @@ const Days: React.FC<Props> = ({
     );
 
     const buttonClass = useCallback(
-        (day: number, type: string) => {
+        (day: number, type: "current" | "previous" | "next") => {
             const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10";
             return cn(
                 baseClass,

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -9,7 +9,7 @@ import { COLORS, DATE_FORMAT, DEFAULT_COLOR, LANGUAGE } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { formatDate, nextMonth, previousMonth } from "../helpers";
 import useOnClickOutside from "../hooks";
-import { Period, DatepickerType } from "../types";
+import { Period, DatepickerType, ColorKeys } from "../types";
 
 import { Arrow, VerticalDash } from "./utils";
 
@@ -225,16 +225,16 @@ const Datepicker: React.FC<DatepickerType> = ({
     }, [startFrom, value]);
 
     // Variables
-    const colorPrimary = useMemo(() => {
+    const safePrimaryColor = useMemo(() => {
         if (COLORS.includes(primaryColor)) {
-            return primaryColor;
+            return primaryColor as ColorKeys;
         }
         return DEFAULT_COLOR;
     }, [primaryColor]);
     const contextValues = useMemo(() => {
         return {
             asSingle,
-            primaryColor: colorPrimary,
+            primaryColor: safePrimaryColor,
             configs,
             calendarContainer: calendarContainerRef,
             arrowContainer: arrowRef,
@@ -272,7 +272,7 @@ const Datepicker: React.FC<DatepickerType> = ({
         };
     }, [
         asSingle,
-        colorPrimary,
+        safePrimaryColor,
         configs,
         hideDatepicker,
         period,
@@ -291,7 +291,6 @@ const Datepicker: React.FC<DatepickerType> = ({
         toggleIcon,
         readOnly,
         displayFormat,
-        firstGotoDate,
         minDate,
         maxDate,
         disabledDates,
@@ -300,7 +299,8 @@ const Datepicker: React.FC<DatepickerType> = ({
         startWeekOn,
         classNames,
         inputRef,
-        popoverDirection
+        popoverDirection,
+        firstGotoDate
     ]);
 
     const containerClassNameOverload = useMemo(() => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
+import { ColorKeys, Colors } from "types";
+
 export const COLORS = [
     "blue",
     "orange",
@@ -17,9 +19,9 @@ export const COLORS = [
     "fuchsia",
     "pink",
     "rose"
-];
+] as const;
 
-export const DEFAULT_COLOR = "blue";
+export const DEFAULT_COLOR: ColorKeys = "blue";
 
 export const LANGUAGE = "en";
 
@@ -35,7 +37,7 @@ export const CALENDAR_SIZE = 42;
 
 // Beware, these maps of colors cannot be replaced with functions using string interpolation such as `bg-${color}-100`
 // as described in Tailwind documentation https://tailwindcss.com/docs/content-configuration#dynamic-class-names
-export const BG_COLOR = {
+export const BG_COLOR: Colors = {
     100: {
         blue: "bg-blue-100",
         orange: "bg-orange-100",
@@ -114,7 +116,7 @@ export const BG_COLOR = {
     }
 };
 
-export const TEXT_COLOR = {
+export const TEXT_COLOR: Colors = {
     500: {
         blue: "text-blue-500",
         orange: "text-orange-500",
@@ -174,7 +176,7 @@ export const TEXT_COLOR = {
     }
 };
 
-export const BORDER_COLOR = {
+export const BORDER_COLOR: Colors = {
     500: {
         blue: "border-blue-500",
         orange: "border-orange-500",
@@ -215,7 +217,7 @@ export const BORDER_COLOR = {
     }
 };
 
-export const RING_COLOR = {
+export const RING_COLOR: Colors = {
     focus: {
         blue: "focus:ring-blue-500",
         orange: "focus:ring-orange-500",
@@ -256,7 +258,7 @@ export const RING_COLOR = {
     }
 };
 
-export const BUTTON_COLOR = {
+export const BUTTON_COLOR: Colors = {
     focus: {
         blue: "focus:ring-blue-500/50 focus:bg-blue-100/50",
         orange: "focus:ring-orange-500/50 focus:bg-orange-100/50",

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -9,13 +9,14 @@ import {
     DateType,
     DateRangeType,
     ClassNamesTypeProp,
-    PopoverDirectionType
+    PopoverDirectionType,
+    ColorKeys
 } from "../types";
 
 interface DatepickerStore {
     input?: React.RefObject<HTMLInputElement>;
     asSingle?: boolean;
-    primaryColor: string;
+    primaryColor: ColorKeys;
     configs?: Configs;
     calendarContainer: React.RefObject<HTMLDivElement> | null;
     arrowContainer: React.RefObject<HTMLDivElement> | null;
@@ -56,8 +57,7 @@ const DatepickerContext = createContext<DatepickerStore>({
     configs: undefined,
     calendarContainer: null,
     arrowContainer: null,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    hideDatepicker: () => {},
+    hideDatepicker: () => null,
     period: { start: null, end: null },
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     changePeriod: period => {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { COLORS } from "../constants";
+
 export interface Period {
     start: string | null;
     end: string | null;
@@ -47,7 +49,7 @@ export type ClassNamesTypeProp = {
 export type PopoverDirectionType = "up" | "down";
 
 export interface DatepickerType {
-    primaryColor?: string;
+    primaryColor?: ColorKeys;
     value: DateValueType;
     onChange: (value: DateValueType, e?: HTMLInputElement | null | undefined) => void;
     useRange?: boolean;
@@ -69,9 +71,17 @@ export interface DatepickerType {
     inputName?: string;
     displayFormat?: string;
     readOnly?: boolean;
-    minDate?: DateType | null;
-    maxDate?: DateType | null;
+    minDate?: Date | null;
+    maxDate?: Date | null;
     disabledDates?: DateRangeType[] | null;
     startWeekOn?: string | null;
     popoverDirection?: PopoverDirectionType;
+}
+
+export type ColorKeys = (typeof COLORS)[number]; // "blue" | "orange"
+
+export interface Colors {
+    [key: string]: {
+        [K in ColorKeys]: string;
+    };
 }


### PR DESCRIPTION
Multiple fixes:
* minDate and maxDate setting now includes the dates provided. Before, if minDate was provided using `new Date()`, comparison would be made using nanoseconds. Since `new Date()` value was created on page load, it would be in the past, making today's date not selectable. Similar could happen on end date in some cases. Now as long as day is matching both dates will be included. Issue https://github.com/onesine/react-tailwindcss-datepicker/issues/117
* ColorKey and Colors types were created for type safety. Now, users using datepicker will see types for `colorPrimary` based on `COLORS` constant. `COLORS` constant will also enforce all color types to be including new colors using `Colors` interface. 