### PR TITLE
Revert the api changes keeping types fixed

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,16 +7,19 @@ export interface Period {
     end: string | null;
 }
 
+interface CustomShortcuts {
+    [key: string]: ShortcutsItem;
+}
+
 interface DefaultShortcuts {
     today?: string;
     yesterday?: string;
     past?: (period: number) => string;
     currentMonth?: string;
     pastMonth?: string;
-    custom?: ShortcutsItem[];
 }
 export interface Configs {
-    shortcuts?: DefaultShortcuts;
+    shortcuts?: DefaultShortcuts | CustomShortcuts;
     footer?: {
         cancel?: string;
         apply?: string;


### PR DESCRIPTION
Reverts API changes to shortcuts while keeping types working.

@onesine this should resolve two issues mentioned from my last commit: https://github.com/onesine/react-tailwindcss-datepicker/pull/133

It's compatible with original API and custom shortcuts can be added before the default ones. I have also completely rewritten the shortcutsOption function.