### PR TITLE
Remove ESLint couldn't determine the plugin "react-hooks" uniquely, i…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,6 @@
         "plugin:react/recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:prettier/recommended",
-        "plugin:react-hooks/recommended",
         "next/core-web-vitals"
     ],
     "overrides": [],


### PR DESCRIPTION
Hi @onesine,
I hope you're doing well! I wanted to bring to your attention a issue that I've encountered after the last update. It seems that the dist directory was not updated, and even reinstalling did not resolve the problem that was fixed in the previous pull request.
After checking I found a small bug during the build process that led to the following error:
```
ESLint couldn't determine the plugin "react-hooks" uniquely.

- /Users/c/atomica/react-tailwindcss-datepicker/node_modules/eslint-config-next/node_modules/eslint-plugin-react-hooks/index.js (loaded in ".eslintrc.json » eslint-config-next/core-web-vitals » /Users/c/atomica/react-tailwindcss-datepicker/node_modules/eslint-config-next/index.js » plugin:react-hooks/recommended")
- /Users/c/atomica/react-tailwindcss-datepicker/node_modules/eslint-plugin-react-hooks/index.js (loaded in ".eslintrc.json » plugin:react-hooks/recommended")

Please remove the "plugins" setting from either config or remove either plugin installation.

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.


```
It appears that there's a conflict with the "react-hooks" ESLint plugin during the build process. After looking into the issue, I believe that you don't need to explicitly include the "react-hooks" plugin in the .eslintrc.json anymore. It's already a dependency at this point, and including it explicitly seems to have caused the build process problem in the new release.