### PR TITLE
type: update types for startDate and endDate to accept `number` values

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface ShortcutsItem {
     };
 }
 
-export type DateType = string | null | Date;
+export type DateType = number | string | null | Date;
 
 export type DateRangeType = {
     startDate: DateType;


### PR DESCRIPTION
Hi! Thanks for your amazing work! I'm using this date picker usefully.

During my usage, I noticed that both startDate and endDate can accept values of type number, even though their current types don't explicitly indicate this compatibility.

To address this, I've made adjustments to the DateType to ensure that it can also accommodate values of type number.

Here are a couple of screenshots for references:

<img width="319" alt="스크린샷 2023-08-10 오전 12 35 56" src="https://github.com/onesine/react-tailwindcss-datepicker/assets/8033896/994285a2-9a2a-4863-99dd-8d5a387666a1">

<img width="720" alt="스크린샷 2023-08-10 오전 12 51 03" src="https://github.com/onesine/react-tailwindcss-datepicker/assets/8033896/10188258-e0ac-4e18-9e66-637bf39ddeb3">

Please let me know if I got something wrong. Thank you.
