### PR TITLE
Fix Missing 'run' Command in Contribution.md for NPM Scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ yarn pret:fix
 **Using npm**
 
 ```sh
-npm pret:fix
+npm run pret:fix
 ```
 
 ## Running playground
@@ -60,7 +60,7 @@ yarn dev
 **Using npm**
 
 ```sh
-npm dev
+npm run dev
 ```
 
 ## Before you make a Pull Request


### PR DESCRIPTION
Fixed an oversight in the Contribution.md file where the necessary 'run' command was omitted between npm 'pret:fix' and 'npm dev'. The corrected command sequence is now 'npm pret:fix && npm run dev', ensuring proper execution of the intended scripts. This update enhances the clarity and correctness of the instructions for contributors.