### PR TITLE
#163 fixes calculation of previous date in other languages

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -71,7 +71,7 @@ const Calendar: React.FC<Props> = ({
     const previous = useCallback(() => {
         return getLastDaysInMonth(
             previousMonth(date),
-            getNumberOfDay(getFirstDayInMonth(date).ddd, startWeekOn)
+            getNumberOfDay(getFirstDayInMonth(date).basic, startWeekOn)
         );
     }, [date, startWeekOn]);
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -143,6 +143,8 @@ export function getNumberOfDay(dayString: string, startWeekOn?: string | null | 
 
     let startDateModifier = 0;
 
+    const dayStringInUs = new Date(dayString).toLocaleDateString("en-US", { weekday: "short" });
+
     if (startWeekOn) {
         switch (startWeekOn) {
             case "mon":
@@ -173,7 +175,7 @@ export function getNumberOfDay(dayString: string, startWeekOn?: string | null | 
 
     ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].forEach(
         (item, index) => {
-            if (item.includes(dayString)) {
+            if (item.includes(dayStringInUs)) {
                 number = (index + startDateModifier) % 7;
             }
         }


### PR DESCRIPTION
Solution for previous days calculation. 

Problem:  when i18n enabled if there is multiple instance of calendar previous date calculation  wrong.

 Solution: dayString gets ddd  when it comes with i18n support it doens't matched with array. So I passed basic and used 'en-Us' form of the dayString.