### PR TITLE
fix: weekday check function for other locales

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -138,6 +138,16 @@ export function getLastElementsInArray(array: number[] = [], size = 0) {
     return result.reverse();
 }
 
+export function generateWeekdayStringsArray() {
+    const weekdays = [];
+    let day = dayjs().startOf("week");
+    for (let i = 0; i < 7; i++) {
+        weekdays.push(formatDate(day, "ddd"));
+        day = day.add(1, "day");
+    }
+    return weekdays;
+}
+
 export function getNumberOfDay(dayString: string, startWeekOn?: string | null | undefined): number {
     let number = 0;
 
@@ -171,13 +181,11 @@ export function getNumberOfDay(dayString: string, startWeekOn?: string | null | 
         }
     }
 
-    ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].forEach(
-        (item, index) => {
-            if (item.includes(dayString)) {
-                number = (index + startDateModifier) % 7;
-            }
+    generateWeekdayStringsArray().forEach((item, index) => {
+        if (item.includes(dayString)) {
+            number = (index + startDateModifier) % 7;
         }
-    );
+    });
 
     return number;
 }


### PR DESCRIPTION
Fixing issue #150 , #221

![Screenshot 2023-12-07 at 6 57 08 PM](https://github.com/onesine/react-tailwindcss-datepicker/assets/5467111/2cebab9a-8f8c-4ffd-a9d8-06ae3ba42a9f)


Problem: 

- Calendar doesn't show previous month, all months start with 1.

Reason:

- This is due to `getNumberOfDay` being stuck at number = 0, when delcaring dayjs.locale() other than "en" globally outside library.

The Fix:

- Instead of using hard-coded weekday string array ["Sunday", ... "Saturday"], a function is created to specifically use previously set locales. 

