### PR TITLE
fix: should wait for button click when both asSingle and showFooter are true

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -149,7 +149,9 @@ const Calendar: React.FC<Props> = ({
                 newStart = fullDay;
                 if (asSingle) {
                     newEnd = fullDay;
-                    chosePeriod(fullDay, fullDay);
+                    if (!showFooter) {
+                        chosePeriod(fullDay, fullDay);
+                    }
                 }
             } else {
                 if (period.start && !period.end) {


### PR DESCRIPTION
This PR addresses #140.

Problem: When `asSingle` is enabled, the datepicker ignores `showFooter` and submits when a value is picked instead of waiting for button click.

Solution: check if `showFooter` is enabled before submitting.