### PR TITLE
Enhancing React Library Feature: Introducing Time Picker Capability

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -11,10 +11,11 @@ export default function Playground() {
         endDate: null
     });
     const [primaryColor, setPrimaryColor] = useState("blue");
-    const [useRange, setUseRange] = useState(true);
-    const [showFooter, setShowFooter] = useState(false);
+    const [useRange, setUseRange] = useState(false);
+    const [showFooter, setShowFooter] = useState(true);
     const [showShortcuts, setShowShortcuts] = useState(false);
-    const [asSingle, setAsSingle] = useState(false);
+    const [asTimePicker, setAsTimePicker] = useState(true);
+    const [asSingle, setAsSingle] = useState(true);
     const [placeholder, setPlaceholder] = useState("");
     const [separator, setSeparator] = useState("~");
     const [i18n, setI18n] = useState("en");
@@ -22,7 +23,7 @@ export default function Playground() {
     const [inputClassName, setInputClassName] = useState("");
     const [containerClassName, setContainerClassName] = useState("");
     const [toggleClassName, setToggleClassName] = useState("");
-    const [displayFormat, setDisplayFormat] = useState("YYYY-MM-DD");
+    const [displayFormat, setDisplayFormat] = useState("DD/MM/YYYY hh:mm A");
     const [readOnly, setReadOnly] = useState(false);
     const [minDate, setMinDate] = useState("");
     const [maxDate, setMaxDate] = useState("");
@@ -92,6 +93,7 @@ export default function Playground() {
                         }
                     }}
                     asSingle={asSingle}
+                    asTimePicker={asTimePicker}
                     placeholder={placeholder}
                     separator={separator}
                     startFrom={
@@ -184,6 +186,20 @@ export default function Playground() {
                             />
                             <label className="block" htmlFor="asSingle">
                                 As Single
+                            </label>
+                        </div>
+                    </div>
+                    <div className="mb-2 w-1/2 sm:w-full">
+                        <div className="inline-flex items-center">
+                            <input
+                                type="checkbox"
+                                className="mr-2 rounded"
+                                id="asTimePicker"
+                                checked={asTimePicker}
+                                onChange={e => setAsTimePicker(e.target.checked)}
+                            />
+                            <label className="block" htmlFor="showFooter">
+                                As Time Picker
                             </label>
                         </div>
                     </div>

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -50,6 +50,9 @@ const Calendar: React.FC<Props> = ({
 }) => {
     // Contexts
     const {
+        hour,
+        minute,
+        periodDay,
         period,
         changePeriod,
         changeDayHover,

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -234,10 +234,6 @@ const Calendar: React.FC<Props> = ({
         setYear(date.year());
     }, [date]);
 
-    useEffect(() => {
-        console.log({ hour, minute, periodDay, period });
-    }, [hour, minute, periodDay, period]);
-
     // Variables
     const calendarData = useMemo(() => {
         return {

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -57,6 +57,7 @@ const Calendar: React.FC<Props> = ({
         changeDatepickerValue,
         hideDatepicker,
         asSingle,
+        asTimePicker,
         i18n,
         startWeekOn,
         input
@@ -129,7 +130,7 @@ const Calendar: React.FC<Props> = ({
                     },
                     ipt
                 );
-                hideDatepicker();
+                if (!asTimePicker) hideDatepicker();
             }
 
             if (period.start && period.end) {
@@ -185,16 +186,17 @@ const Calendar: React.FC<Props> = ({
             }
         },
         [
-            asSingle,
+            date,
+            period.start,
+            period.end,
+            showFooter,
+            input,
             changeDatepickerValue,
+            asTimePicker,
+            hideDatepicker,
             changeDayHover,
             changePeriod,
-            date,
-            hideDatepicker,
-            period.end,
-            period.start,
-            showFooter,
-            input
+            asSingle
         ]
     );
 

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -5,6 +5,7 @@ import { CALENDAR_SIZE, DATE_FORMAT } from "../../constants";
 import DatepickerContext from "../../contexts/DatepickerContext";
 import {
     formatDate,
+    formatDateTimeToISO,
     getDaysInMonth,
     getFirstDayInMonth,
     getFirstDaysInMonth,
@@ -128,8 +129,12 @@ const Calendar: React.FC<Props> = ({
                 const ipt = input?.current;
                 changeDatepickerValue(
                     {
-                        startDate: dayjs(start).format(DATE_FORMAT),
-                        endDate: dayjs(end).format(DATE_FORMAT)
+                        startDate: asTimePicker
+                            ? formatDateTimeToISO(start, hour, minute, periodDay)
+                            : dayjs(start).format(DATE_FORMAT),
+                        endDate: asTimePicker
+                            ? formatDateTimeToISO(end, hour, minute, periodDay)
+                            : dayjs(end).format(DATE_FORMAT)
                     },
                     ipt
                 );
@@ -196,6 +201,9 @@ const Calendar: React.FC<Props> = ({
             input,
             changeDatepickerValue,
             asTimePicker,
+            hour,
+            minute,
+            periodDay,
             hideDatepicker,
             changeDayHover,
             changePeriod,
@@ -225,6 +233,10 @@ const Calendar: React.FC<Props> = ({
     useEffect(() => {
         setYear(date.year());
     }, [date]);
+
+    useEffect(() => {
+        console.log({ hour, minute, periodDay, period });
+    }, [hour, minute, periodDay, period]);
 
     // Variables
     const calendarData = useMemo(() => {

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -5,6 +5,7 @@ import Calendar from "../components/Calendar";
 import Footer from "../components/Footer";
 import Input from "../components/Input";
 import Shortcuts from "../components/Shortcuts";
+import Time from "../components/Time";
 import { COLORS, DATE_FORMAT, DEFAULT_COLOR, LANGUAGE } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { formatDate, nextMonth, previousMonth } from "../helpers";
@@ -22,6 +23,7 @@ const Datepicker: React.FC<DatepickerType> = ({
     showShortcuts = false,
     configs = undefined,
     asSingle = false,
+    asTimePicker = false,
     placeholder = null,
     separator = "~",
     startFrom = null,
@@ -61,6 +63,10 @@ const Datepicker: React.FC<DatepickerType> = ({
     const [inputText, setInputText] = useState<string>("");
     const [inputRef, setInputRef] = useState(React.createRef<HTMLInputElement>());
 
+    const [hour, setHour] = useState<string>("1");
+    const [minute, setMinute] = useState<string>("00");
+    const [periodDay, setPeriodDay] = useState<"AM" | "PM">("PM");
+
     // Custom Hooks use
     useOnClickOutside(containerRef, () => {
         const container = containerRef.current;
@@ -92,6 +98,21 @@ const Datepicker: React.FC<DatepickerType> = ({
             }, 300);
         }
     }, []);
+
+    /* Start Time */
+    const changeHour = useCallback((hour: string) => {
+        setHour(hour);
+    }, []);
+
+    const changeMinute = useCallback((minute: string) => {
+        setMinute(minute);
+    }, []);
+
+    const changePeriodDay = useCallback((periodDay: "AM" | "PM") => {
+        setPeriodDay(periodDay);
+    }, []);
+
+    /* End Time */
 
     /* Start First */
     const firstGotoDate = useCallback(
@@ -247,6 +268,7 @@ const Datepicker: React.FC<DatepickerType> = ({
     const contextValues = useMemo(() => {
         return {
             asSingle,
+            asTimePicker,
             primaryColor: safePrimaryColor,
             configs,
             calendarContainer: calendarContainerRef,
@@ -260,6 +282,9 @@ const Datepicker: React.FC<DatepickerType> = ({
             changeInputText: (newText: string) => setInputText(newText),
             updateFirstDate: (newDate: dayjs.Dayjs) => firstGotoDate(newDate),
             changeDatepickerValue: onChange,
+            changeHour,
+            changeMinute,
+            changePeriodDay,
             showFooter,
             placeholder,
             separator,
@@ -286,6 +311,7 @@ const Datepicker: React.FC<DatepickerType> = ({
         };
     }, [
         asSingle,
+        asTimePicker,
         safePrimaryColor,
         configs,
         hideDatepicker,
@@ -293,6 +319,9 @@ const Datepicker: React.FC<DatepickerType> = ({
         dayHover,
         inputText,
         onChange,
+        changeHour,
+        changeMinute,
+        changePeriodDay,
         showFooter,
         placeholder,
         separator,
@@ -376,7 +405,7 @@ const Datepicker: React.FC<DatepickerType> = ({
                                 )}
                             </div>
                         </div>
-
+                        {asSingle && asTimePicker && <Time />}
                         {showFooter && <Footer />}
                     </div>
                 </div>

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -100,18 +100,11 @@ const Datepicker: React.FC<DatepickerType> = ({
     }, []);
 
     /* Start Time */
-    const changeHour = useCallback((hour: string) => {
-        setHour(hour);
-    }, []);
+    const changeHour = useCallback((hour: string) => setHour(hour), []);
 
-    const changeMinute = useCallback((minute: string) => {
-        setMinute(minute);
-    }, []);
+    const changeMinute = useCallback((minute: string) => setMinute(minute), []);
 
-    const changePeriodDay = useCallback((periodDay: PeriodDay) => {
-        setPeriodDay(periodDay);
-    }, []);
-
+    const changePeriodDay = useCallback((periodDay: PeriodDay) => setPeriodDay(periodDay), []);
     /* End Time */
 
     /* Start First */

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -10,7 +10,7 @@ import { COLORS, DATE_FORMAT, DEFAULT_COLOR, LANGUAGE } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { formatDate, nextMonth, previousMonth } from "../helpers";
 import useOnClickOutside from "../hooks";
-import { Period, DatepickerType, ColorKeys } from "../types";
+import { Period, DatepickerType, ColorKeys, PeriodDay } from "../types";
 
 import { Arrow, VerticalDash } from "./utils";
 
@@ -65,7 +65,7 @@ const Datepicker: React.FC<DatepickerType> = ({
 
     const [hour, setHour] = useState<string>("1");
     const [minute, setMinute] = useState<string>("00");
-    const [periodDay, setPeriodDay] = useState<"AM" | "PM">("PM");
+    const [periodDay, setPeriodDay] = useState<PeriodDay>("PM");
 
     // Custom Hooks use
     useOnClickOutside(containerRef, () => {
@@ -108,7 +108,7 @@ const Datepicker: React.FC<DatepickerType> = ({
         setMinute(minute);
     }, []);
 
-    const changePeriodDay = useCallback((periodDay: "AM" | "PM") => {
+    const changePeriodDay = useCallback((periodDay: PeriodDay) => {
         setPeriodDay(periodDay);
     }, []);
 
@@ -282,6 +282,9 @@ const Datepicker: React.FC<DatepickerType> = ({
             changeInputText: (newText: string) => setInputText(newText),
             updateFirstDate: (newDate: dayjs.Dayjs) => firstGotoDate(newDate),
             changeDatepickerValue: onChange,
+            hour,
+            minute,
+            periodDay,
             changeHour,
             changeMinute,
             changePeriodDay,
@@ -319,6 +322,9 @@ const Datepicker: React.FC<DatepickerType> = ({
         dayHover,
         inputText,
         onChange,
+        hour,
+        minute,
+        periodDay,
         changeHour,
         changeMinute,
         changePeriodDay,

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -375,15 +375,18 @@ const Datepicker: React.FC<DatepickerType> = ({
                                     showShortcuts ? "md:pl-2" : "md:pl-1"
                                 } pr-2 lg:pr-1`}
                             >
-                                <Calendar
-                                    date={firstDate}
-                                    onClickPrevious={previousMonthFirst}
-                                    onClickNext={nextMonthFirst}
-                                    changeMonth={changeFirstMonth}
-                                    changeYear={changeFirstYear}
-                                    minDate={minDate}
-                                    maxDate={maxDate}
-                                />
+                                <div>
+                                    <Calendar
+                                        date={firstDate}
+                                        onClickPrevious={previousMonthFirst}
+                                        onClickNext={nextMonthFirst}
+                                        changeMonth={changeFirstMonth}
+                                        changeYear={changeFirstYear}
+                                        minDate={minDate}
+                                        maxDate={maxDate}
+                                    />
+                                    {asSingle && asTimePicker && <Time />}
+                                </div>
 
                                 {useRange && (
                                     <>
@@ -404,7 +407,6 @@ const Datepicker: React.FC<DatepickerType> = ({
                                 )}
                             </div>
                         </div>
-                        {asSingle && asTimePicker && <Time />}
                         {showFooter && <Footer />}
                     </div>
                 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,7 @@ import { PrimaryButton, SecondaryButton } from "./utils";
 
 const Footer: React.FC = () => {
     // Contexts
-    const { hideDatepicker, period, changeDatepickerValue, configs, classNames } =
+    const { asTimePicker, period, configs, classNames, changeDatepickerValue, hideDatepicker } =
         useContext(DatepickerContext);
 
     // Functions
@@ -34,8 +34,12 @@ const Footer: React.FC = () => {
                     onClick={() => {
                         if (period.start && period.end) {
                             changeDatepickerValue({
-                                startDate: dayjs(period.start).format(DATE_FORMAT),
-                                endDate: dayjs(period.end).format(DATE_FORMAT)
+                                startDate: asTimePicker
+                                    ? dayjs(period.start).toISOString()
+                                    : dayjs(period.start).format(DATE_FORMAT),
+                                endDate: asTimePicker
+                                    ? dayjs(period.end).toISOString()
+                                    : dayjs(period.start).format(DATE_FORMAT)
                             });
                             hideDatepicker();
                         }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -25,6 +25,7 @@ const Input: React.FC<Props> = (e: Props) => {
         hideDatepicker,
         changeDatepickerValue,
         asSingle,
+        asTimePicker,
         placeholder,
         separator,
         disabled,
@@ -70,7 +71,12 @@ const Input: React.FC<Props> = (e: Props) => {
 
             const dates = [];
 
-            if (asSingle) {
+            if (asSingle && asTimePicker) {
+                const date = parseFormattedDate(inputValue, displayFormat);
+                if (dateIsValid(date.toDate())) {
+                    dates.push(date.format(DATE_FORMAT));
+                }
+            } else if (asSingle) {
                 const date = parseFormattedDate(inputValue, displayFormat);
                 if (dateIsValid(date.toDate())) {
                     dates.push(date.format(DATE_FORMAT));

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -120,7 +120,15 @@ const Input: React.FC<Props> = (e: Props) => {
 
             changeInputText(e.target.value);
         },
-        [asSingle, displayFormat, separator, changeDatepickerValue, changeDayHover, changeInputText]
+        [
+            asSingle,
+            asTimePicker,
+            changeInputText,
+            displayFormat,
+            separator,
+            changeDatepickerValue,
+            changeDayHover
+        ]
     );
 
     const handleInputKeyDown = useCallback(

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -71,12 +71,7 @@ const Input: React.FC<Props> = (e: Props) => {
 
             const dates = [];
 
-            if (asSingle && asTimePicker) {
-                const date = parseFormattedDate(inputValue, displayFormat);
-                if (dateIsValid(date.toDate())) {
-                    dates.push(date.format(DATE_FORMAT));
-                }
-            } else if (asSingle) {
+            if (asSingle || asTimePicker) {
                 const date = parseFormattedDate(inputValue, displayFormat);
                 if (dateIsValid(date.toDate())) {
                     dates.push(date.format(DATE_FORMAT));

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -43,7 +43,7 @@ const Time: React.FC = () => {
     const selectClassname = cn(
         "!bg-[length:0.75rem_0.75rem]",
         "bg-[right_0.5rem_center]",
-        "!bg-no-repeat !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
+        "!bg-no-repeat !appearance-none !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
         "!pl-2 !pr-6 !py-1 rounded-[8px] !w-fit",
         "!border border-gray-300 focus:border-none",
         `${ringFocusColor}`

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,6 +1,7 @@
+import dayjs from "dayjs";
 import React, { ChangeEvent, useContext } from "react";
 
-import { RING_COLOR } from "../constants";
+import { DATE_FORMAT, RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { classNames as cn, formatDateTimeToISO } from "../helpers";
 import { PeriodDay } from "../types";
@@ -55,34 +56,36 @@ const Time: React.FC = () => {
     const handleChangeHour = (e: ChangeEvent<HTMLSelectElement>) => {
         changeHour(e.target.value);
 
-        if (period.start && period.end) {
+        if (period.start && period.end)
             changeDatepickerValue({
                 startDate: formatDateTimeToISO(period.start, e.target.value, minute, periodDay),
                 endDate: formatDateTimeToISO(period.end, e.target.value, minute, periodDay)
             });
-        }
     };
 
     const handleChangeMinute = (e: ChangeEvent<HTMLSelectElement>) => {
         changeMinute(e.target.value);
 
-        if (period.start && period.end) {
+        if (period.start && period.end)
             changeDatepickerValue({
                 startDate: formatDateTimeToISO(period.start, hour, e.target.value, periodDay),
                 endDate: formatDateTimeToISO(period.end, hour, e.target.value, periodDay)
             });
-        }
     };
 
     const handleChangePeriodDay = (e: ChangeEvent<HTMLSelectElement>) => {
         changePeriodDay(e.target.value as PeriodDay);
 
-        if (period.start && period.end) {
+        if (period.start && period.end)
             changeDatepickerValue({
-                startDate: formatDateTimeToISO(period.start, hour, minute, e.target.value),
-                endDate: formatDateTimeToISO(period.end, hour, minute, e.target.value)
+                startDate: formatDateTimeToISO(
+                    period.start,
+                    hour,
+                    minute,
+                    e.target.value as PeriodDay
+                ),
+                endDate: formatDateTimeToISO(period.end, hour, minute, e.target.value as PeriodDay)
             });
-        }
     };
 
     return (
@@ -97,10 +100,10 @@ const Time: React.FC = () => {
                     }}
                 >
                     {HOURS.map((_, index) => {
-                        const hour = index + 1;
+                        const hr = index + 1;
                         return (
-                            <option key={hour} value={hour}>
-                                {hour}
+                            <option key={hr} value={hr}>
+                                {hr}
                             </option>
                         );
                     })}
@@ -110,17 +113,18 @@ const Time: React.FC = () => {
                     name="minute"
                     className={cn(selectClassname, "mr-4")}
                     onChange={handleChangeMinute}
+                    value={minute}
                     style={{
                         backgroundImage: "url(" + dataUri + ")"
                     }}
                 >
                     {MINUTES.map((_, index) => {
-                        const minute = index * 5;
+                        const min = index * 5;
                         return (
-                            <option key={minute} value={minute}>
+                            <option key={min} value={min}>
                                 {new Intl.NumberFormat("en-US", {
                                     minimumIntegerDigits: 2
-                                }).format(minute)}
+                                }).format(min)}
                             </option>
                         );
                     })}
@@ -129,6 +133,7 @@ const Time: React.FC = () => {
                     name="ampm"
                     className={selectClassname}
                     onChange={handleChangePeriodDay}
+                    value={periodDay}
                     style={{
                         backgroundImage: "url(" + dataUri + ")"
                     }}

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -22,16 +22,27 @@ const Time: React.FC = () => {
     const ringFocusColor = RING_COLOR.focus[primaryColor as keyof typeof RING_COLOR.focus];
 
     const svgString = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M8.35355 4.06066C8.15829 3.8654 7.84171 3.8654 7.64645 4.06066L5.35355 6.35355C5.15829 6.54882 4.84171 6.54882 4.64645 6.35355C4.45118 6.15829 4.45118 5.84171 4.64645 5.64645L6.93934 3.35356C7.52513 2.76777 8.47487 2.76777 9.06066 3.35355L11.3536 5.64645C11.5488 5.84171 11.5488 6.15829 11.3536 6.35355C11.1583 6.54882 10.8417 6.54882 10.6464 6.35355L8.35355 4.06066Z" fill="#6b7280"/>
-          <path fill-rule="evenodd" clip-rule="evenodd" d="M8.35355 11.9393C8.15829 12.1346 7.84171 12.1346 7.64645 11.9393L5.35355 9.64645C5.15829 9.45119 4.84171 9.45119 4.64645 9.64645C4.45118 9.84171 4.45118 10.1583 4.64645 10.3536L6.93934 12.6464C7.52513 13.2322 8.47487 13.2322 9.06066 12.6464L11.3536 10.3536C11.5488 10.1583 11.5488 9.84171 11.3536 9.64645C11.1583 9.45119 10.8417 9.45119 10.6464 9.64645L8.35355 11.9393Z" fill="#6b7280"/>
+        <svg 
+            class="flex-shrink-0 w-3 h-3" 
+            xmlns="http://www.w3.org/2000/svg" 
+            width="24" 
+            height="24" 
+            viewBox="0 0 24 24" 
+            fill="none" 
+            stroke="#6b7280" 
+            stroke-width="2.5" 
+            stroke-linecap="round" 
+            stroke-linejoin="round"
+        >
+            <path d="m7 15 5 5 5-5"></path>
+            <path d="m7 9 5-5 5 5"></path>
         </svg>
       `;
     const dataUri = `data:image/svg+xml;base64,${Buffer.from(svgString).toString("base64")}`;
 
     const selectClassname = cn(
-        "!bg-[length:1rem_1rem]",
-        "bg-[right_0.25rem_center]",
+        "!bg-[length:0.75rem_0.75rem]",
+        "bg-[right_0.5rem_center]",
         "!bg-no-repeat !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
         "!pl-2 !pr-6 !py-1 rounded-[8px] !w-fit",
         "!border border-gray-300 focus:border-none",

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -4,24 +4,36 @@ import { RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { classNames as cn } from "../helpers";
 
+import { DoubleVerticalChevronRightIcon } from "./utils";
+
 import { PeriodDay } from "types";
 
 const Time: React.FC = () => {
     // Contexts
-
     const { primaryColor, changeHour, changeMinute, changePeriodDay } =
         useContext(DatepickerContext);
+
     const ringFocusColor = RING_COLOR.focus[primaryColor as keyof typeof RING_COLOR.focus];
 
-    const HOURS = Array.from({ length: 12 });
-    const MINUTES = Array.from({ length: 12 });
+    const svgString = `
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M8.35355 4.06066C8.15829 3.8654 7.84171 3.8654 7.64645 4.06066L5.35355 6.35355C5.15829 6.54882 4.84171 6.54882 4.64645 6.35355C4.45118 6.15829 4.45118 5.84171 4.64645 5.64645L6.93934 3.35356C7.52513 2.76777 8.47487 2.76777 9.06066 3.35355L11.3536 5.64645C11.5488 5.84171 11.5488 6.15829 11.3536 6.35355C11.1583 6.54882 10.8417 6.54882 10.6464 6.35355L8.35355 4.06066Z" fill="#6b7280"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M8.35355 11.9393C8.15829 12.1346 7.84171 12.1346 7.64645 11.9393L5.35355 9.64645C5.15829 9.45119 4.84171 9.45119 4.64645 9.64645C4.45118 9.84171 4.45118 10.1583 4.64645 10.3536L6.93934 12.6464C7.52513 13.2322 8.47487 13.2322 9.06066 12.6464L11.3536 10.3536C11.5488 10.1583 11.5488 9.84171 11.3536 9.64645C11.1583 9.45119 10.8417 9.45119 10.6464 9.64645L8.35355 11.9393Z" fill="#6b7280"/>
+        </svg>
+      `;
+    const dataUri = `data:image/svg+xml;base64,${Buffer.from(svgString).toString("base64")}`;
 
     const selectClassname = cn(
-        "!bg-none !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
-        "!px-2 !py-1 rounded-[8px] !w-fit",
+        "!bg-[length:1rem_1rem]",
+        "bg-[right_0.25rem_center]",
+        "!bg-no-repeat !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
+        "!pl-2 !pr-6 !py-1 rounded-[8px] !w-fit",
         "!border border-gray-300 focus:border-none",
         `${ringFocusColor}`
     );
+
+    const HOURS = Array.from({ length: 12 });
+    const MINUTES = Array.from({ length: 12 });
 
     const handleChangeHour = (e: ChangeEvent<HTMLSelectElement>) => changeHour(e.target.value);
 
@@ -33,11 +45,18 @@ const Time: React.FC = () => {
     return (
         <div className="w-full md:w-auto flex items-center justify-center space-x-3">
             <div className="pb-6">
-                <select name="hour" className={selectClassname} onChange={handleChangeHour}>
+                <select
+                    name="hour"
+                    className={selectClassname}
+                    onChange={handleChangeHour}
+                    style={{
+                        backgroundImage: "url(" + dataUri + ")"
+                    }}
+                >
                     {HOURS.map((_, index) => {
                         const hour = index + 1;
                         return (
-                            <option key={hour} value={hour + 1}>
+                            <option key={hour} value={hour}>
                                 {hour}
                             </option>
                         );
@@ -48,11 +67,14 @@ const Time: React.FC = () => {
                     name="minute"
                     className={cn(selectClassname, "mr-4")}
                     onChange={handleChangeMinute}
+                    style={{
+                        backgroundImage: "url(" + dataUri + ")"
+                    }}
                 >
                     {MINUTES.map((_, index) => {
                         const minute = index * 5;
                         return (
-                            <option key={minute} value={minute + 1}>
+                            <option key={minute} value={minute}>
                                 {new Intl.NumberFormat("en-US", {
                                     minimumIntegerDigits: 2
                                 }).format(minute)}
@@ -60,7 +82,14 @@ const Time: React.FC = () => {
                         );
                     })}
                 </select>
-                <select name="ampm" className={selectClassname} onChange={handleChangePeriodDay}>
+                <select
+                    name="ampm"
+                    className={selectClassname}
+                    onChange={handleChangePeriodDay}
+                    style={{
+                        backgroundImage: "url(" + dataUri + ")"
+                    }}
+                >
                     <option value="AM">AM</option>
                     <option value="PM">PM</option>
                 </select>

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,10 +1,9 @@
-import React, { ChangeEvent, useCallback, useContext } from "react";
+import React, { ChangeEvent, useContext } from "react";
 
 import { RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { classNames as cn, formatDateTimeToISO } from "../helpers";
-
-import { PeriodDay } from "types";
+import { PeriodDay } from "../types";
 
 const Time: React.FC = () => {
     // Contexts

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,7 +1,6 @@
-import dayjs from "dayjs";
 import React, { ChangeEvent, useContext } from "react";
 
-import { DATE_FORMAT, RING_COLOR } from "../constants";
+import { RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { classNames as cn, formatDateTimeToISO } from "../helpers";
 import { PeriodDay } from "../types";

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,0 +1,71 @@
+import dayjs from "dayjs";
+import React, { ChangeEvent, useCallback, useContext } from "react";
+
+import { BG_COLOR, BORDER_COLOR, DATE_FORMAT, RING_COLOR } from "../constants";
+import DatepickerContext from "../contexts/DatepickerContext";
+import { classNames as cn } from "../helpers";
+
+const Time: React.FC = () => {
+    // Contexts
+
+    const { primaryColor, changeHour, changeMinute, changePeriodDay } =
+        useContext(DatepickerContext);
+    const ringFocusColor = RING_COLOR.focus[primaryColor as keyof typeof RING_COLOR.focus];
+
+    const HOURS = Array.from({ length: 12 });
+    const MINUTES = Array.from({ length: 12 });
+
+    const selectClassname = cn(
+        "!bg-none !bg-transparent !text-sm !text-center !outline-none !focus:outline-none",
+        "!px-2 !py-1 rounded-[8px] !w-fit",
+        "!border border-gray-300 focus:border-none",
+        `${ringFocusColor}`
+    );
+
+    const handleChangeHour = (e: ChangeEvent<HTMLSelectElement>) => changeHour(e.target.value);
+
+    const handleChangeMinute = (e: ChangeEvent<HTMLSelectElement>) => changeMinute(e.target.value);
+
+    const handleChangePeriodDay = (e: ChangeEvent<HTMLSelectElement>) =>
+        changePeriodDay(e.target.value as "AM" | "PM");
+
+    return (
+        <div className="w-full md:w-auto flex items-center justify-center space-x-3">
+            <div className="pb-6">
+                <select name="hour" className={selectClassname} onChange={handleChangeHour}>
+                    {HOURS.map((_, index) => {
+                        const hour = index + 1;
+                        return (
+                            <option key={hour} value={hour + 1}>
+                                {hour}
+                            </option>
+                        );
+                    })}
+                </select>
+                <span className="text-xl mx-3">:</span>
+                <select
+                    name="minute"
+                    className={cn(selectClassname, "mr-4")}
+                    onChange={handleChangeMinute}
+                >
+                    {MINUTES.map((_, index) => {
+                        const minute = index * 5;
+                        return (
+                            <option key={minute} value={minute + 1}>
+                                {new Intl.NumberFormat("en-US", {
+                                    minimumIntegerDigits: 2
+                                }).format(minute)}
+                            </option>
+                        );
+                    })}
+                </select>
+                <select name="ampm" className={selectClassname} onChange={handleChangePeriodDay}>
+                    <option value="AM">AM</option>
+                    <option value="PM">PM</option>
+                </select>
+            </div>
+        </div>
+    );
+};
+
+export default Time;

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,9 +1,10 @@
-import dayjs from "dayjs";
 import React, { ChangeEvent, useCallback, useContext } from "react";
 
-import { BG_COLOR, BORDER_COLOR, DATE_FORMAT, RING_COLOR } from "../constants";
+import { RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 import { classNames as cn } from "../helpers";
+
+import { PeriodDay } from "types";
 
 const Time: React.FC = () => {
     // Contexts
@@ -27,7 +28,7 @@ const Time: React.FC = () => {
     const handleChangeMinute = (e: ChangeEvent<HTMLSelectElement>) => changeMinute(e.target.value);
 
     const handleChangePeriodDay = (e: ChangeEvent<HTMLSelectElement>) =>
-        changePeriodDay(e.target.value as "AM" | "PM");
+        changePeriodDay(e.target.value as PeriodDay);
 
     return (
         <div className="w-full md:w-auto flex items-center justify-center space-x-3">

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -2,16 +2,23 @@ import React, { ChangeEvent, useCallback, useContext } from "react";
 
 import { RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
-import { classNames as cn } from "../helpers";
-
-import { DoubleVerticalChevronRightIcon } from "./utils";
+import { classNames as cn, formatDateTimeToISO } from "../helpers";
 
 import { PeriodDay } from "types";
 
 const Time: React.FC = () => {
     // Contexts
-    const { primaryColor, changeHour, changeMinute, changePeriodDay } =
-        useContext(DatepickerContext);
+    const {
+        hour,
+        minute,
+        periodDay,
+        period,
+        primaryColor,
+        changeDatepickerValue,
+        changeHour,
+        changeMinute,
+        changePeriodDay
+    } = useContext(DatepickerContext);
 
     const ringFocusColor = RING_COLOR.focus[primaryColor as keyof typeof RING_COLOR.focus];
 
@@ -35,12 +42,38 @@ const Time: React.FC = () => {
     const HOURS = Array.from({ length: 12 });
     const MINUTES = Array.from({ length: 12 });
 
-    const handleChangeHour = (e: ChangeEvent<HTMLSelectElement>) => changeHour(e.target.value);
+    const handleChangeHour = (e: ChangeEvent<HTMLSelectElement>) => {
+        changeHour(e.target.value);
 
-    const handleChangeMinute = (e: ChangeEvent<HTMLSelectElement>) => changeMinute(e.target.value);
+        if (period.start && period.end) {
+            changeDatepickerValue({
+                startDate: formatDateTimeToISO(period.start, e.target.value, minute, periodDay),
+                endDate: formatDateTimeToISO(period.end, e.target.value, minute, periodDay)
+            });
+        }
+    };
 
-    const handleChangePeriodDay = (e: ChangeEvent<HTMLSelectElement>) =>
+    const handleChangeMinute = (e: ChangeEvent<HTMLSelectElement>) => {
+        changeMinute(e.target.value);
+
+        if (period.start && period.end) {
+            changeDatepickerValue({
+                startDate: formatDateTimeToISO(period.start, hour, e.target.value, periodDay),
+                endDate: formatDateTimeToISO(period.end, hour, e.target.value, periodDay)
+            });
+        }
+    };
+
+    const handleChangePeriodDay = (e: ChangeEvent<HTMLSelectElement>) => {
         changePeriodDay(e.target.value as PeriodDay);
+
+        if (period.start && period.end) {
+            changeDatepickerValue({
+                startDate: formatDateTimeToISO(period.start, hour, minute, e.target.value),
+                endDate: formatDateTimeToISO(period.end, hour, minute, e.target.value)
+            });
+        }
+    };
 
     return (
         <div className="w-full md:w-auto flex items-center justify-center space-x-3">

--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -118,32 +118,6 @@ export const DoubleChevronRightIcon: React.FC<IconProps> = ({ className = "w-6 h
     );
 };
 
-export const DoubleVerticalChevronRightIcon: React.FC<IconProps> = ({ className = "w-6 h-6" }) => {
-    return (
-        <svg
-            className={className}
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-        >
-            <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M8.35355 4.06066C8.15829 3.8654 7.84171 3.8654 7.64645 4.06066L5.35355 6.35355C5.15829 6.54882 4.84171 6.54882 4.64645 6.35355C4.45118 6.15829 4.45118 5.84171 4.64645 5.64645L6.93934 3.35356C7.52513 2.76777 8.47487 2.76777 9.06066 3.35355L11.3536 5.64645C11.5488 5.84171 11.5488 6.15829 11.3536 6.35355C11.1583 6.54882 10.8417 6.54882 10.6464 6.35355L8.35355 4.06066Z"
-                fill="#6b7280"
-            />
-            <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M8.35355 11.9393C8.15829 12.1346 7.84171 12.1346 7.64645 11.9393L5.35355 9.64645C5.15829 9.45119 4.84171 9.45119 4.64645 9.64645C4.45118 9.84171 4.45118 10.1583 4.64645 10.3536L6.93934 12.6464C7.52513 13.2322 8.47487 13.2322 9.06066 12.6464L11.3536 10.3536C11.5488 10.1583 11.5488 9.84171 11.3536 9.64645C11.1583 9.45119 10.8417 9.45119 10.6464 9.64645L8.35355 11.9393Z"
-                fill="#6b7280"
-            />
-        </svg>
-    );
-};
-
 // eslint-disable-next-line react/display-name,@typescript-eslint/ban-types
 export const Arrow = React.forwardRef<HTMLDivElement, {}>((props, ref) => {
     return (

--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -4,7 +4,7 @@ import { BG_COLOR, BORDER_COLOR, BUTTON_COLOR, RING_COLOR } from "../constants";
 import DatepickerContext from "../contexts/DatepickerContext";
 
 interface IconProps {
-    className: string;
+    className?: string;
 }
 
 interface Button {
@@ -113,6 +113,32 @@ export const DoubleChevronRightIcon: React.FC<IconProps> = ({ className = "w-6 h
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 d="M11.25 4.5l7.5 7.5-7.5 7.5m-6-15l7.5 7.5-7.5 7.5"
+            />
+        </svg>
+    );
+};
+
+export const DoubleVerticalChevronRightIcon: React.FC<IconProps> = ({ className = "w-6 h-6" }) => {
+    return (
+        <svg
+            className={className}
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+        >
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8.35355 4.06066C8.15829 3.8654 7.84171 3.8654 7.64645 4.06066L5.35355 6.35355C5.15829 6.54882 4.84171 6.54882 4.64645 6.35355C4.45118 6.15829 4.45118 5.84171 4.64645 5.64645L6.93934 3.35356C7.52513 2.76777 8.47487 2.76777 9.06066 3.35355L11.3536 5.64645C11.5488 5.84171 11.5488 6.15829 11.3536 6.35355C11.1583 6.54882 10.8417 6.54882 10.6464 6.35355L8.35355 4.06066Z"
+                fill="#6b7280"
+            />
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8.35355 11.9393C8.15829 12.1346 7.84171 12.1346 7.64645 11.9393L5.35355 9.64645C5.15829 9.45119 4.84171 9.45119 4.64645 9.64645C4.45118 9.84171 4.45118 10.1583 4.64645 10.3536L6.93934 12.6464C7.52513 13.2322 8.47487 13.2322 9.06066 12.6464L11.3536 10.3536C11.5488 10.1583 11.5488 9.84171 11.3536 9.64645C11.1583 9.45119 10.8417 9.45119 10.6464 9.64645L8.35355 11.9393Z"
+                fill="#6b7280"
             />
         </svg>
     );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -27,6 +27,8 @@ export const LANGUAGE = "en";
 
 export const DATE_FORMAT = "YYYY-MM-DD";
 
+export const DATE_TIME_FORMAT = "DD/MM/YYYY hh:mm A";
+
 export const START_WEEK = "sun";
 
 export const DATE_LOOKING_OPTIONS = ["forward", "backward", "middle"];

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -10,7 +10,8 @@ import {
     DateRangeType,
     ClassNamesTypeProp,
     PopoverDirectionType,
-    ColorKeys
+    ColorKeys,
+    PeriodDay
 } from "../types";
 
 interface DatepickerStore {
@@ -23,9 +24,12 @@ interface DatepickerStore {
     arrowContainer: React.RefObject<HTMLDivElement> | null;
     hideDatepicker: () => void;
     period: Period;
+    hour: string;
+    minute: string;
+    periodDay: PeriodDay;
     changeHour: (hour: string) => void;
     changeMinute: (minute: string) => void;
-    changePeriodDay: (periodDay: "AM" | "PM") => void;
+    changePeriodDay: (periodDay: PeriodDay) => void;
     changePeriod: (period: Period) => void;
     dayHover: string | null;
     changeDayHover: (day: string | null) => void;
@@ -73,6 +77,9 @@ const DatepickerContext = createContext<DatepickerStore>({
     inputText: "",
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     changeInputText: text => {},
+    hour: "",
+    minute: "",
+    periodDay: "PM",
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     changeHour: text => {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -16,12 +16,16 @@ import {
 interface DatepickerStore {
     input?: React.RefObject<HTMLInputElement>;
     asSingle?: boolean;
+    asTimePicker?: boolean;
     primaryColor: ColorKeys;
     configs?: Configs;
     calendarContainer: React.RefObject<HTMLDivElement> | null;
     arrowContainer: React.RefObject<HTMLDivElement> | null;
     hideDatepicker: () => void;
     period: Period;
+    changeHour: (hour: string) => void;
+    changeMinute: (minute: string) => void;
+    changePeriodDay: (periodDay: "AM" | "PM") => void;
     changePeriod: (period: Period) => void;
     dayHover: string | null;
     changeDayHover: (day: string | null) => void;
@@ -69,6 +73,12 @@ const DatepickerContext = createContext<DatepickerStore>({
     inputText: "",
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     changeInputText: text => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+    changeHour: text => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+    changeMinute: text => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
+    changePeriodDay: text => {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars
     updateFirstDate: date => {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-unused-vars

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -628,24 +628,24 @@ export function dateIsValid(date: Date | number) {
 }
 
 export function formatDateTimeToISO(
-    dateIncoming: Date,
-    hourIncoming: number,
-    minute: number,
+    dateIncoming: Date | string,
+    hourIncoming: string,
+    minute: string,
     period: string
 ): string {
     // Adjust hour based on period (AM/PM)
     const hour = (() => {
-        if (period === "PM" && hourIncoming !== 12) return hourIncoming + 12;
+        if (period === "PM" && hourIncoming !== String(12)) return hourIncoming + 12;
 
-        if (period === "AM" && hourIncoming === 12) return 0;
+        if (period === "AM" && hourIncoming === String(12)) return 0;
 
         return hourIncoming;
     })();
 
     // Create a new Date object and set the components
     const date = new Date(dateIncoming);
-    date.setHours(hour);
-    date.setMinutes(minute);
+    date.setHours(Number(hour));
+    date.setMinutes(Number(minute));
 
     // Format date to ISO 8601
     const isoString = date.toISOString();

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -626,3 +626,28 @@ export function loadLanguageModule(language = LANGUAGE) {
 export function dateIsValid(date: Date | number) {
     return date instanceof Date && !isNaN(date.getTime());
 }
+
+export function formatDateTimeToISO(
+    dateIncoming: Date,
+    hourIncoming: number,
+    minute: number,
+    period: string
+): string {
+    // Adjust hour based on period (AM/PM)
+    const hour = (() => {
+        if (period === "PM" && hourIncoming !== 12) return hourIncoming + 12;
+
+        if (period === "AM" && hourIncoming === 12) return 0;
+
+        return hourIncoming;
+    })();
+
+    // Create a new Date object and set the components
+    const date = new Date(dateIncoming);
+    date.setHours(hour);
+    date.setMinutes(minute);
+
+    // Format date to ISO 8601
+    const isoString = date.toISOString();
+    return isoString;
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,10 +2,12 @@ import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import weekday from "dayjs/plugin/weekday";
 
+import { DATE_FORMAT, LANGUAGE } from "../constants";
+
 dayjs.extend(weekday);
 dayjs.extend(customParseFormat);
 
-import { DATE_FORMAT, LANGUAGE } from "../constants";
+import { PeriodDay } from "types";
 
 export function classNames(...classes: (false | null | undefined | string)[]) {
     return classes.filter(Boolean).join(" ");
@@ -631,23 +633,25 @@ export function formatDateTimeToISO(
     dateIncoming: Date | string,
     hourIncoming: string,
     minute: string,
-    period: string
+    periodDay: PeriodDay
 ): string {
     // Adjust hour based on period (AM/PM)
-    const hour = (() => {
-        if (period === "PM" && hourIncoming !== String(12)) return hourIncoming + 12;
+    const calculateHour = (hourIncoming: string, periodDay: PeriodDay): string => {
+        if (periodDay === "PM" && hourIncoming !== String(12))
+            return String(Number(hourIncoming) + 12);
 
-        if (period === "AM" && hourIncoming === String(12)) return 0;
+        if (periodDay === "AM" && hourIncoming === String(12)) return "0";
 
         return hourIncoming;
-    })();
+    };
+
+    const hour = calculateHour(hourIncoming, periodDay);
 
     // Create a new Date object and set the components
-    const date = new Date(dateIncoming);
-    date.setHours(Number(hour));
-    date.setMinutes(Number(minute));
+    const date = dayjs(dateIncoming).add(Number(hour), "hours").add(Number(minute), "minutes");
 
     // Format date to ISO 8601
     const isoString = date.toISOString();
+
     return isoString;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,7 @@ export interface DatepickerType {
     showShortcuts?: boolean;
     configs?: Configs;
     asSingle?: boolean;
+    asTimePicker?: boolean;
     placeholder?: string;
     separator?: string;
     startFrom?: Date | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ import React from "react";
 
 import { COLORS } from "../constants";
 
+export type PeriodDay = "AM" | "PM";
+
 export interface Period {
     start: string | null;
     end: string | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,35 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        "lib": ["dom", "esnext"],
-        "module": "esnext",
-        "jsx": "preserve",
-        "moduleResolution": "node",
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "noImplicitReturns": true,
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
-        "baseUrl": "src/",
-        "declaration": true,
-        "outDir": "./dist",
-        "inlineSources": true,
-        "sourceMap": true,
-        "rootDir": "src",
-        "allowJs": true,
-        "skipLibCheck": true,
-        "noEmit": true,
-        "resolveJsonModule": true,
-        "isolatedModules": true
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "module": "esnext",
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "baseUrl": "src/",
+    "declaration": true,
+    "outDir": "./dist",
+    "inlineSources": true,
+    "sourceMap": true,
+    "rootDir": "src",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "incremental": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,35 +1,28 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "lib": [
-      "dom",
-      "esnext"
-    ],
-    "module": "esnext",
-    "jsx": "preserve",
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitReturns": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "baseUrl": "src/",
-    "declaration": true,
-    "outDir": "./dist",
-    "inlineSources": true,
-    "sourceMap": true,
-    "rootDir": "src",
-    "allowJs": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "incremental": true
-  },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "compilerOptions": {
+        "target": "esnext",
+        "lib": ["dom", "esnext"],
+        "module": "esnext",
+        "jsx": "preserve",
+        "moduleResolution": "node",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "baseUrl": "src/",
+        "declaration": true,
+        "outDir": "./dist",
+        "inlineSources": true,
+        "sourceMap": true,
+        "rootDir": "src",
+        "allowJs": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "incremental": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION

Hey folks! (@onesine ) Big news! I've just dropped a slick new update this library, and we couldn't be more excited to share it with you. But first, let's give a round of applause to the about this library. Seriously, the structure they've cooked up is like a dream to work with, especially when you throw Next.js into the mix. Smooth sailing all the way!

Now, onto the juicy stuff. I've added a Time Picker feature, we didn't even have to add extra libraries, it could kept it clean and mean, sticking to what we've got and just sprinkling in some magic.

One of the standout additions in this update is the introduction of the `asTimePicker` parameter. By simply toggling this boolean flag, users can now effortlessly transform their components into time pickers, expanding the library's versatility without compromising its simplicity.

```typescript
asTimePicker?: boolean;
```

Below, you'll find the interface detailing the implementation of the Time Picker feature, along with a clear demonstration of the return format in ISO hour. This ensures consistency and compatibility across various environments, empowering developers to integrate this feature seamlessly into their projects.

Thank you for your continued support and enthusiasm for this library. Together, let's continue pushing to improve this! 🚀

<img width="1469" alt="image" src="https://github.com/onesine/react-tailwindcss-datepicker/assets/17098382/00c9ee9d-1854-4336-9683-b01096ae765f">

<img width="1470" alt="image" src="https://github.com/onesine/react-tailwindcss-datepicker/assets/17098382/0110e75c-912e-453c-bddd-b033d69e56b9">

<img width="1469" alt="image" src="https://github.com/onesine/react-tailwindcss-datepicker/assets/17098382/cd4fd457-9589-429f-b883-505adf630c7f">

