### PR TITLE
[Fix 🐛] Update date format in Week component

### DIFF
--- a/src/components/Calendar/Week.tsx
+++ b/src/components/Calendar/Week.tsx
@@ -43,7 +43,7 @@ const Week = () => {
                     {ucFirst(
                         shortString(
                             dateFormat(
-                                new Date(`2022-11-${6 + item + startDateModifier}`),
+                                new Date(2022, 10, 6 + item + startDateModifier),
                                 "ddd",
                                 i18n
                             ) || ""


### PR DESCRIPTION
The code changes update the date format in the Week component of the Calendar. Instead of using a string to specify the date, it now uses the `new Date()` constructor with specific parameters. This change improves the readability and maintainability of the code.

The error occurs because the week is iterated using the JavaScript `Date` constructor as a string, which causes variations between the actual day.

Example of how it's iterated and its result:
```javascript
new Date('2022-11-6')  // -> Sun Nov 06 2022 00:00:00 GMT-0600
new Date('2022-11-7')  // -> Mon Nov 07 2022 00:00:00 GMT-0600
new Date('2022-11-8')  // -> Tue Nov 08 2022 00:00:00 GMT-0600
new Date('2022-11-9')  // -> Wed Nov 09 2022 00:00:00 GMT-0600
new Date('2022-11-10') // -> Wed Nov 09 2022 18:00:00 GMT-0600
new Date('2022-11-11') // -> Thu Nov 10 2022 18:00:00 GMT-0600
new Date('2022-11-12') // -> Fri Nov 11 2022 18:00:00 GMT-0600
```

If we iterate using the `Date(year, month, day)` constructor, these variations do not occur:
```javascript
new Date(2022,10,6)  // -> Sun Nov 06 2022 00:00:00 GMT-0600
new Date(2022,10,7)  // -> Mon Nov 07 2022 00:00:00 GMT-0600
new Date(2022,10,8)  // -> Tue Nov 08 2022 00:00:00 GMT-0600
new Date(2022,10,9)  // -> Wed Nov 09 2022 00:00:00 GMT-0600
new Date(2022,10,10) // -> Thu Nov 10 2022 00:00:00 GMT-0600
new Date(2022,10,11) // -> Fri Nov 11 2022 00:00:00 GMT-0600
new Date(2022,10,12) // -> Sat Nov 12 2022 00:00:00 GMT-0600
```

