### PR TITLE
[Fix 🐛] update month display logic in Calendar component

### DIFF
--- a/src/components/Calendar/Months.tsx
+++ b/src/components/Calendar/Months.tsx
@@ -30,7 +30,7 @@ const Months = (props: Props) => {
                     }}
                     active={currentMonth === item}
                 >
-                    {dateFormat(new Date(`2022-${item}-01`), "MMM", i18n)}
+                    {dateFormat(new Date(2022, item - 1, 1), "MMM", i18n)}
                 </RoundedButton>
             ))}
         </div>


### PR DESCRIPTION
Fix list of month buttons, which are not displayed correctly

Steps of the iteration of months
```javascript
new Date('2022-8-01')  // -> Mon Aug 01 2022 00:00:00 GMT-0600
new Date('2022-9-01')  // -> Thu Sep 01 2022 00:00:00 GMT-0600
new Date('2022-10-01') // -> Fri Sep 30 2022 18:00:00 GMT-0600
new Date('2022-11-01') // -> Mon Oct 31 2022 18:00:00 GMT-0600
```

#276 (Months are not displayed correctly #276)


Safari
![image](https://github.com/user-attachments/assets/f6c79796-75a0-4967-a8eb-d7eb4e425d34)

Chrome
![image](https://github.com/user-attachments/assets/d642dba0-1052-49b8-9374-495b4b519f4b)

Firefox
![image](https://github.com/user-attachments/assets/c17e5352-042a-41c4-8576-5e04db482059)
