### PR TITLE
Fix/sync second calendar on shortcut selected

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -100,6 +100,13 @@ export default function Playground() {
                                     start: new Date(),
                                     end: new Date(new Date().setDate(new Date().getDate() + 8))
                                 }
+                            },
+                            last6Months: {
+                                text: "Last 6 months",
+                                period: {
+                                    start: new Date(new Date().setMonth(new Date().getMonth() - 6)),
+                                    end: new Date()
+                                }
                             }
                         },
                         footer: {

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -334,6 +334,7 @@ const Datepicker = (props: DatepickerType) => {
             toggleClassName,
             toggleIcon,
             updateFirstDate: (newDate: Date) => firstGotoDate(newDate),
+            updateLastDate: (newDate: Date) => secondGotoDate(newDate),
             value
         };
     }, [
@@ -368,7 +369,8 @@ const Datepicker = (props: DatepickerType) => {
         toggleClassName,
         toggleIcon,
         value,
-        firstGotoDate
+        firstGotoDate,
+        secondGotoDate
     ]);
 
     const containerClassNameOverload = useMemo(() => {

--- a/src/components/Shortcuts.tsx
+++ b/src/components/Shortcuts.tsx
@@ -18,6 +18,7 @@ const ItemTemplate = memo((props: ItemTemplateProps) => {
         period,
         changePeriod,
         updateFirstDate,
+        updateLastDate,
         dayHover,
         changeDayHover,
         hideDatepicker,
@@ -53,6 +54,7 @@ const ItemTemplate = memo((props: ItemTemplateProps) => {
             );
 
             if (item.start) updateFirstDate(item.start);
+            if (item.end) updateLastDate(item.end);
             hideDatepicker();
         },
         [
@@ -64,7 +66,8 @@ const ItemTemplate = memo((props: ItemTemplateProps) => {
             input,
             period.end,
             period.start,
-            updateFirstDate
+            updateFirstDate,
+            updateLastDate
         ]
     );
 

--- a/src/contexts/DatepickerContext.ts
+++ b/src/contexts/DatepickerContext.ts
@@ -69,6 +69,7 @@ interface DatepickerStore {
     toggleIcon?: (open: boolean) => ReactNode;
 
     updateFirstDate: (date: Date) => void;
+    updateLastDate: (date: Date) => void;
 
     value: DateValueType;
 }
@@ -122,6 +123,7 @@ const DatepickerContext = createContext<DatepickerStore>({
     toggleIcon: undefined,
 
     updateFirstDate: () => {},
+    updateLastDate: () => {},
 
     value: null
 });


### PR DESCRIPTION
This PR fixes an issue where shortcuts caused incorrect behavior, preventing the second calendar from syncing with the selected range.

before
![before-fix](https://github.com/user-attachments/assets/ffbd54f9-75ba-4794-97e1-88fddf1cf247)
after
![after-fix](https://github.com/user-attachments/assets/63dd73b3-507f-4f2b-acae-6c506366c362)
