### PR TITLE
fix: clear icon(X) won't open popover

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -177,7 +177,6 @@ const Input = () => {
             const input = inputRef.current;
 
             if (input) {
-                input.focus();
                 if (inputText) {
                     changeInputText("");
                     if (dayHover) {
@@ -192,6 +191,8 @@ const Input = () => {
                             input
                         );
                     }
+                } else {
+                    input.focus();
                 }
             }
         }


### PR DESCRIPTION
Closes #305 
Clear icon will now clear the data and won't open the popover

https://github.com/user-attachments/assets/67906c7c-e310-4aa5-911f-410f8d8d9f52

